### PR TITLE
Add Fahrenheit and Celsius temperature swapping option in other settings, fix alarm but its only Fahrenheit and I include a line to swap it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 Changes:
-- Modified to show temperatures in Fahrenheit.
 - Shortened time to start up (reduce splash screen times.)
-
+- Add temperature units (C/F) option to menu somewhere
 Future plans:
 - Add serial commands?
   - Get pieces of info
   - Turn off
-- Add temperature units (C/F) option to menu somewhere
+
 
 # T-Lite-Internal-FW (M5StickC-Plus + MLX90640 Thermal HAT)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 Changes:
 - Shortened time to start up (reduce splash screen times.)
 - Add temperature units (C/F) option to menu somewhere
+
+
+
 Future plans:
-- Add serial commands?
+  - Add serial commands?
   - Get pieces of info
   - Turn off
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -20,18 +20,18 @@ board_build.f_cpu = 240000000L
 monitor_speed = 115200
 upload_speed = 1500000
 monitor_filters = esp32_exception_decoder, time, colorize
-lib_deps = M5Stack/M5Unified @ 0.1.2
-           bblanchon/ArduinoJson
+lib_deps = bblanchon/ArduinoJson
+           M5Stack/M5Unified
 
 [env:release]
 build_type = release
 build_flags = -DCORE_DEBUG_LEVEL=0 -O3
 extra_scripts = post:generate_user_custom.py
-custom_firmware_version = 0.0.8
+custom_firmware_version = 0.0.11
 custom_firmware_name = TLite-FW
 custom_firmware_suffix = .bin
 custom_firmware_dir = r:\
 
-[env:debug]
-build_type = debug
-build_flags = -DCORE_DEBUG_LEVEL=5
+;[env:debug]
+;build_type = debug
+;build_flags = -DCORE_DEBUG_LEVEL=5

--- a/src/command_processor.cpp
+++ b/src/command_processor.cpp
@@ -65,6 +65,27 @@ static inline void gpio_hi(int_fast8_t pin) { *get_gpio_hi_reg(pin) = 1 << (pin 
 static inline void gpio_lo(int_fast8_t pin) { *get_gpio_lo_reg(pin) = 1 << (pin & 31); }
 /* clang-format on */
 
+static int8_t _battery_state = 0;
+static int8_t _battery_level = 0;
+static bool _battery_request = false;
+
+void updateBattery(void) {
+    if (M5.Power.getType() == m5::Power_Class::pmic_ip5306) {
+        _battery_request = true;
+    } else {
+        _battery_state = M5.Power.isCharging();
+        _battery_level = M5.Power.getBatteryLevel();
+    }
+}
+
+int8_t getBatteryLevel(void) {
+    return _battery_level;
+}
+
+int8_t getBatteryState(void) {
+    return _battery_state;
+}
+
 static void IRAM_ATTR mlxTask(void* main_handle) {
     gpio_num_t PIN_IN_SDA = GPIO_NUM_0;
     gpio_num_t PIN_IN_SCL = GPIO_NUM_26;
@@ -152,6 +173,11 @@ static void IRAM_ATTR mlxTask(void* main_handle) {
             static constexpr const uint8_t delay_tbl[] = {32, 16, 8, 4,
                                                           2,  1,  1, 1};
             vTaskDelay(delay_tbl[rate]);
+        }
+        if (_battery_request) {
+            _battery_request = false;
+            _battery_state   = M5.Power.isCharging();
+            _battery_level   = M5.Power.getBatteryLevel();
         }
     }
     vTaskDelete(nullptr);

--- a/src/command_processor.hpp
+++ b/src/command_processor.hpp
@@ -23,6 +23,8 @@ void setRate(uint8_t rate);
 void setFilter(uint8_t level);
 void setEmissivity(uint8_t percent);
 uint32_t getRecvCount(void);
-
+void updateBattery(void);
+int8_t getBatteryLevel(void);
+int8_t getBatteryState(void);
 m5::MLX90640_Class::temp_data_t* getTemperatureData(void);
 }  // namespace command_processor

--- a/src/common_header.cpp
+++ b/src/common_header.cpp
@@ -11,7 +11,6 @@ constexpr const char* config_param_t::common_off_on_text[];
 
 constexpr const char* config_param_t::misc_language_text[];
 
-
 constexpr const uint8_t config_param_t::misc_cpuspeed_value[];
 constexpr const uint8_t config_param_t::sens_refreshrate_value[];
 constexpr const uint8_t config_param_t::sens_noisefilter_value[];

--- a/src/common_header.cpp
+++ b/src/common_header.cpp
@@ -11,6 +11,7 @@ constexpr const char* config_param_t::common_off_on_text[];
 
 constexpr const char* config_param_t::misc_language_text[];
 
+
 constexpr const uint8_t config_param_t::misc_cpuspeed_value[];
 constexpr const uint8_t config_param_t::sens_refreshrate_value[];
 constexpr const uint8_t config_param_t::sens_noisefilter_value[];

--- a/src/common_header.h
+++ b/src/common_header.h
@@ -5,19 +5,65 @@
 
 static constexpr const uint8_t firmware_ver_major = 0;
 static constexpr const uint8_t firmware_ver_minor = 0;
-static constexpr const uint8_t firmware_ver_patch = 8;
+static constexpr const uint8_t firmware_ver_patch = 10;
 
 static constexpr uint8_t frame_width  = 32;
 static constexpr uint8_t frame_height = 24;
 
-static constexpr inline float convertRawToTemperature(int32_t rawdata) {
-    return ((((((float)rawdata / 128) - 64.0f)*9)/5)+32.0f); // Farenheit
-    // return ((float)rawdata / 128) - 64.0f; // Celcius
-}
-static constexpr inline int32_t convertTemperatureToRaw(float temperature) {
-    return (((((temperature-32)*5)/9) + 64) * 128); // Farenheit
-    // return (temperature + 64) * 128; // Celcius
-}
+
+
+
+
+
+
+
+
+
+  
+
+
+
+
+
+  // static constexpr inline float convertRawToCelsius(int32_t rawdata) {
+  //     return ((float)rawdata / 128) - 64.0f;
+  // }
+
+   static  inline float convertRawToCelsius(int32_t rawdata, int temp_mode ) {
+    float value = 0 ;
+
+    if( temp_mode == 1 )
+        value =  ((((((float)rawdata / 128) - 64.0f)*9)/5)+32.0f); 
+    else
+        value = ((float)rawdata / 128) - 64.0f;
+
+    return value ;
+   }
+
+
+static inline float convertCelsiusToRaw(float temperature, int temp_mode ) {
+    float value = 0 ;
+
+    if( temp_mode == 1 )
+        value =  (((((temperature-32)*5)/9) + 64) * 128); 
+    else
+        value = (temperature + 64) * 128;
+
+    return value ;
+   }
+
+
+
+
+   static constexpr inline int32_t convertCelsiusToRaw(float temperature) {
+    return (temperature + 64) * 128;
+   }
+
+
+//return (((((temperature-32)*5)/9) + 64) * 128); // Farenheit
+   
+    
+    
 
 static constexpr const char mon_tbl[12][4] = {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
@@ -986,6 +1032,19 @@ struct config_param_t {
         misc_color_max,
     };
 
+
+    enum misc_temp_mode_t {
+       
+        misc_temp_mode_Celsius,
+        misc_temp_mode_Fahrenheit,
+        misc_temp_mode_max,
+    };
+    static constexpr const int temp_mode_value[] = {0, 1};
+    
+    
+
+
+
     enum cloud_interval_t {
         cloud_interval_5sec,
         cloud_interval_10sec,
@@ -1049,6 +1108,7 @@ struct config_param_t {
     static void misc_brightness_func(misc_brightness_t);
     static void misc_language_func(misc_language_t);
     static void misc_volume_func(misc_volume_t);
+    
     static void misc_color_func(misc_color_t v);
     static void misc_backtofactory_func(uint8_t);
 
@@ -1073,6 +1133,35 @@ struct config_param_t {
         },
         net_setup_mode_t ::net_setup_mode_off,
         net_setup_mode_t ::net_setup_mode_max};
+
+
+
+
+
+    config_property_localize_enum_t<misc_temp_mode_t> misc_temp_mode = {
+        {"Temperature", "温度", "温度"},
+        (const localize_text_t[]){
+            {"Celcius", "摄氏度", "摂氏"},
+            {"Fahrenheit", "华氏度", "華氏"},
+            
+
+        },
+        misc_temp_mode_t ::misc_temp_mode_Fahrenheit,
+        misc_temp_mode_t ::misc_temp_mode_max};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     config_property_localize_enum_t<cloud_interval_t> cloud_interval = {
         {"Upload Interval", "上传间隔时间", "アップロード間隔"},
@@ -1249,6 +1338,13 @@ struct config_param_t {
         misc_language_t ::misc_language_max,
         misc_language_func};
 
+
+    
+
+
+    
+    
+    
     // config_property_enum_t<misc_language_t>    misc_language     = {
     // misc_language_text          , misc_language_t   ::misc_language_en ,
     // misc_language_t   ::misc_language_max, misc_language_func };

--- a/src/common_header.h
+++ b/src/common_header.h
@@ -11,25 +11,7 @@ static constexpr uint8_t frame_width  = 32;
 static constexpr uint8_t frame_height = 24;
 
 
-
-
-
-
-
-
-
-
-  
-
-
-
-
-
-  // static constexpr inline float convertRawToCelsius(int32_t rawdata) {
-  //     return ((float)rawdata / 128) - 64.0f;
-  // }
-
-   static  inline float convertRawToCelsius(int32_t rawdata, int temp_mode ) {
+   static inline float convertRawToCelsius(int32_t rawdata, int temp_mode ) {
     float value = 0 ;
 
     if( temp_mode == 1 )
@@ -52,18 +34,6 @@ static inline float convertCelsiusToRaw(float temperature, int temp_mode ) {
     return value ;
    }
 
-
-
-
-   static constexpr inline int32_t convertCelsiusToRaw(float temperature) {
-    return (temperature + 64) * 128;
-   }
-
-
-//return (((((temperature-32)*5)/9) + 64) * 128); // Farenheit
-   
-    
-    
 
 static constexpr const char mon_tbl[12][4] = {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",

--- a/src/common_header.h
+++ b/src/common_header.h
@@ -34,7 +34,6 @@ static inline float convertCelsiusToRaw(float temperature, int temp_mode ) {
     return value ;
    }
 
-
 static constexpr const char mon_tbl[12][4] = {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
@@ -864,6 +863,19 @@ struct config_param_t {
         alarm_mode_hightemp,
         alarm_mode_max,
     };
+
+enum alarm_temp_mode_t {
+    alarm_temp_modeF,
+    alarm_temp_modeC,
+        
+    };
+
+
+
+
+
+
+
     // static constexpr const char* alarm_mode_text[] = { "Disable", "Lower",
     // "Higher" };
 
@@ -1030,10 +1042,24 @@ struct config_param_t {
     static constexpr const uint16_t cloud_interval_value[] = {
         5, 10, 30, 60, 120, 300, 600, 1800, 3600};
 
-    static void alarm_temperature_text_func(char* text_buf, size_t buf_len,
-                                            uint16_t v) {
-        snprintf(text_buf, buf_len, "%3.1fC", (float)v / 128 - 64);
-    }
+
+
+
+
+static void alarm_temperature_text_func(char* text_buf, size_t buf_len, uint16_t v) {
+    float temperature;
+    
+    
+        temperature = (((((float)v / 128) - 64.0f) * 9) / 5) + 32.0f;
+        snprintf(text_buf, buf_len, "%3.1fF", temperature);
+    
+        
+        //temperature = ((float)v / 128) - 64.0f;
+        //snprintf(text_buf, buf_len, "%3.1fC", temperature);
+    
+
+    
+}
 
     static void sens_temperature_text_func(char* text_buf, size_t buf_len,
                                            int32_t v) {
@@ -1078,7 +1104,6 @@ struct config_param_t {
     static void misc_brightness_func(misc_brightness_t);
     static void misc_language_func(misc_language_t);
     static void misc_volume_func(misc_volume_t);
-    
     static void misc_color_func(misc_color_t v);
     static void misc_backtofactory_func(uint8_t);
 
@@ -1103,10 +1128,7 @@ struct config_param_t {
         },
         net_setup_mode_t ::net_setup_mode_off,
         net_setup_mode_t ::net_setup_mode_max};
-
-
-
-
+        
 
     config_property_localize_enum_t<misc_temp_mode_t> misc_temp_mode = {
         {"Temperature", "温度", "温度"},
@@ -1118,19 +1140,6 @@ struct config_param_t {
         },
         misc_temp_mode_t ::misc_temp_mode_Fahrenheit,
         misc_temp_mode_t ::misc_temp_mode_max};
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 
     config_property_localize_enum_t<cloud_interval_t> cloud_interval = {
@@ -1150,8 +1159,12 @@ struct config_param_t {
         cloud_interval_t ::cloud_interval_max};
 
     config_property_value_t<uint16_t> alarm_temperature = {
-        alarm_temperature_text_func, (100 + 64) * 128, (-50 + 64) * 128,
-        (350 + 64) * 128, 32};
+    alarm_temperature_text_func,  // Function pointer to the text formatting function
+    (100 + 64) * 128,             // Default value for the alarm temperature
+    (-50 + 64) * 128,             // Minimum value for the alarm temperature
+    (350 + 64) * 128,             // Maximum value for the alarm temperature
+    32};                          // Step size for adjustments
+    
 
     config_property_localize_enum_t<alarm_mode_t> alarm_mode = {
         {"Alarm Mode", "报警触发条件", "アラーム条件"},
@@ -1308,13 +1321,6 @@ struct config_param_t {
         misc_language_t ::misc_language_max,
         misc_language_func};
 
-
-    
-
-
-    
-    
-    
     // config_property_enum_t<misc_language_t>    misc_language     = {
     // misc_language_text          , misc_language_t   ::misc_language_en ,
     // misc_language_t   ::misc_language_max, misc_language_func };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -207,7 +207,6 @@ static constexpr const char NVS_NAMESPACE[]         = "__tlite_nvs__";
 static constexpr const char KEY_ALARM_TEMPERATURE[] = "alm_temp";
 static constexpr const char KEY_ALARM_REFERENCE[]   = "alm_ref";
 static constexpr const char KEY_ALARM_MODE[]        = "alm_mode";
-// static constexpr const char KEY_ALARM_BEHAVIOR[]    = "alm_behavior";
 static constexpr const char KEY_SENS_REFRESHRATE[] = "refreshrate";
 static constexpr const char KEY_SENS_NOISEFILTER[] = "noisefilter";
 static constexpr const char KEY_SENS_MONITORAREA[] = "monitorarea";
@@ -219,7 +218,6 @@ static constexpr const char KEY_NET_RUNNING_MODE[] = "net_running";
 static constexpr const char KEY_NET_JPGQUALITY[]   = "jpg_quality";
 static constexpr const char KEY_CLOUD_UPLOAD[]     = "upload_ena";
 static constexpr const char KEY_CLOUD_INTERVAL[]   = "upload_int";
-static constexpr const char KEY_MISC_TEMP_MODE[]   = "temp_mode";
 static constexpr const char KEY_CLOUD_TOKEN[]      = "ezdata_token";
 static constexpr const char KEY_NET_TIMEZONE[]     = "timezone";
 static constexpr const char KEY_MISC_CPUSPEED[]    = "cpuspeed";
@@ -229,7 +227,8 @@ static constexpr const char KEY_MISC_LANGUAGE[]    = "language";
 static constexpr const char KEY_MISC_LAYOUT[]      = "layout";
 static constexpr const char KEY_MISC_COLOR[]       = "color";
 static constexpr const char KEY_MISC_POINTER[]     = "pointer";
-// static constexpr const char KEY_MISC_ROTATION[]     = "msc_rotation";
+static constexpr const char KEY_MISC_TEMP_MODE[]   = "temp_mode";
+
 
 std::string convert(const std::string& src) {
     std::string res;
@@ -271,7 +270,6 @@ void config_param_t::saveNvs(void) {
     pref.putUChar(KEY_MISC_LAYOUT, misc_layout);
     pref.putUChar(KEY_MISC_COLOR, misc_color);
     pref.putString(KEY_CLOUD_TOKEN, cloud_token.c_str());
-
     pref.end();
     ESP_LOGD("DEBUG", "saveNvs out");
 }
@@ -1647,7 +1645,8 @@ class config_ui_t : public container_ui_t {
             new token_ui_t{&lt_Cloud_Confirm_Code, &draw_param.cloud_token});
         cloud_config_ui.addItem(
             new value_ui_t{&draw_param.cloud_interval, true});
-        alarm_config_ui.addItem(new value_ui_t{&draw_param.alarm_mode, true});
+        alarm_config_ui.addItem(
+            new value_ui_t{&draw_param.alarm_mode, true});
         alarm_config_ui.addItem(
             new value_ui_t{&lt_Temperature, &draw_param.alarm_temperature});
         alarm_config_ui.addItem(
@@ -3665,6 +3664,15 @@ void setup(void) {
             snprintf(lines[line_idx++], line_len, "Mode:%s",
                      draw_param.net_running_mode.getText());
         }
+
+
+
+
+
+
+
+
+
         if (draw_param.alarm_mode) {
             snprintf(lines[line_idx++], line_len, "Alarm:%s %3.1fC",
                      draw_param.alarm_mode.getText(),


### PR DESCRIPTION
Automatic Fahrenheit and Celsius temperature swapping for alarm probably won't happen due to how unreadable the code is.